### PR TITLE
Fix dependency for Paypal

### DIFF
--- a/view/frontend/web/js/action/set-payment-method.js
+++ b/view/frontend/web/js/action/set-payment-method.js
@@ -1,0 +1,14 @@
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+define([
+           'Magento_Checkout/js/model/quote',
+           'Magento_Checkout/js/action/set-payment-information'
+       ], function (quote, setPaymentInformation) {
+    'use strict';
+
+    return function (messageContainer) {
+        return setPaymentInformation(messageContainer, quote.paymentMethod());
+    };
+});

--- a/view/frontend/web/js/view/payment/method-renderer/nuvei.js
+++ b/view/frontend/web/js/view/payment/method-renderer/nuvei.js
@@ -8,7 +8,7 @@ define(
     [
         'jquery',
         'Magento_Payment/js/view/payment/cc-form',
-        'Magento_Paypal/js/action/set-payment-method',
+        'Nuvei_Payments/js/action/set-payment-method',
         'jquery.redirect',
         'ko',
         'Magento_Checkout/js/model/quote',


### PR DESCRIPTION
Magento_Paypal module is not required for Magento instance and can be missing in some projects
This PR just removes this dependency